### PR TITLE
fix: handle Google OAuth errors gracefully

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
 
   if (!code) {
     return NextResponse.redirect(
-      new URL(`/auth/error?message=No+code+provided`, requestUrl.origin),
+      new URL('/login?error=auth_callback_failed', requestUrl.origin),
     );
   }
 
@@ -19,13 +19,10 @@ export async function GET(req: Request) {
 
     // Redirect to the intended page or default system dashboard
     return NextResponse.redirect(new URL(next, requestUrl.origin));
-  } catch (error) {
-    // If exchange fails (e.g., link expired), redirect to error page
+  } catch {
+    // If exchange fails (e.g., link expired), redirect back to login with error
     return NextResponse.redirect(
-      new URL(
-        `/auth/error?message=${encodeURIComponent((error as Error).message)}`,
-        requestUrl.origin,
-      ),
+      new URL('/login?error=auth_callback_failed', requestUrl.origin),
     );
   }
 }

--- a/app/api/auth/google/route.ts
+++ b/app/api/auth/google/route.ts
@@ -19,10 +19,7 @@ export async function GET(req: Request) {
 
   if (error || !data.url) {
     return NextResponse.redirect(
-      new URL(
-        `/auth/error?message=${encodeURIComponent(error?.message || 'Failed to initialize Google OAuth')}`,
-        requestUrl.origin,
-      ),
+      new URL('/login?error=google_unavailable', requestUrl.origin),
     );
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -24,6 +24,8 @@
     "usernameRequiredError": "Username is required.",
     "passwordRequiredError": "Password is required.",
     "loginFailed": "Failed to login.",
+    "googleUnavailable": "Google sign-in is temporarily unavailable. Please use the magic link instead.",
+    "authCallbackFailed": "Authentication failed. Please try again.",
     "welcome": "Welcome, {name}!"
   },
   "landing": {

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -24,6 +24,8 @@
     "usernameRequiredError": "Username é obrigatório.",
     "passwordRequiredError": "Senha é obrigatória.",
     "loginFailed": "Falha ao realizar login.",
+    "googleUnavailable": "Login com Google indisponível no momento. Use o link mágico.",
+    "authCallbackFailed": "Falha na autenticação. Tente novamente.",
     "welcome": "Bem-vindo, {name}!"
   },
   "landing": {

--- a/src/frontend/components/LoginForm.tsx
+++ b/src/frontend/components/LoginForm.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useTranslations } from 'next-intl';
@@ -36,7 +38,17 @@ type LoginFormValues = z.infer<typeof loginSchema>;
 export default function LoginForm() {
   const { sendMagicLink } = useAuth();
   const t = useTranslations('login');
+  const searchParams = useSearchParams();
   const [emailSent, setEmailSent] = useState(false);
+
+  useEffect(() => {
+    const error = searchParams.get('error');
+    if (error === 'google_unavailable') {
+      toast.error(t('googleUnavailable'));
+    } else if (error === 'auth_callback_failed') {
+      toast.error(t('authCallbackFailed'));
+    }
+  }, [searchParams, t]);
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),


### PR DESCRIPTION
## Summary

- Redirect OAuth errors to `/login?error=google_unavailable` instead of the non-existent `/auth/error` page
- Redirect auth callback failures to `/login?error=auth_callback_failed`
- Show localized toast notification on the login page guiding users to the magic link
- Add i18n translations (EN + PT) for both error states

Closes #5

## Test plan

- [ ] Click "Continuar com Google" with Google provider disabled → should redirect to `/login` and show toast: "Login com Google indisponível no momento. Use o link mágico."
- [ ] Visit `/api/auth/callback` without a code → should redirect to `/login` with auth callback error toast
- [ ] Switch language to EN and verify English error messages display correctly
- [ ] Verify magic link flow still works as expected (no regressions)